### PR TITLE
Add configuration to allow additional no space operators

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
 build --macos_minimum_os=12.0 --host_macos_minimum_os=12.0
+build --disk_cache=~/.bazel_cache

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,3 +15,7 @@ steps:
     commands:
       - echo "+++ Analyze"
       - make analyze
+  - label: "TSan"
+    commands:
+      - echo "+++ Test"
+      - bazel test --xcode_version_config=//bazel:xcode_config --test_output=streamed --build_tests_only --features=tsan --test_timeout=600 //Tests/...

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,12 @@ steps:
       - bundle exec danger --verbose
   - label: "Analyze"
     commands:
+      - echo "+++ Build With Bazel"
+      - bazel build -c opt swiftlint
+      - echo "+++ Build With SwiftPM"
+      - swift build
       - echo "+++ Analyze"
-      - make analyze
+      - bazel test -c opt --test_output=streamed --test_timeout=1800 --spawn_strategy=local --test_env=PROJECT_ROOT=$(bazel info workspace) analyze
   - label: "TSan"
     commands:
       - echo "+++ Test"

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ benchmark_*
 osscheck/
 docs/
 rule_docs/
+bazel.tar.gz
+bazel.tar.gz.sha256
 
 # Swift Package Manager
 #

--- a/BUILD
+++ b/BUILD
@@ -55,20 +55,35 @@ filegroup(
 
 # Release
 
-genrule(
-    name = "release",
+filegroup(
+    name = "release_files",
     srcs = [
-        "//:BUILD",
-        "//:LICENSE",
+        "BUILD",
+        "LICENSE",
         "//:LintInputs",
         "//Tests:BUILD",
-        "//bazel:BazelDirectorySources",
+        "//bazel:release_files",
     ],
-    outs = ["bazel.tar.gz"],
-    cmd = """
+)
+
+# TODO: Use rules_pkg
+genrule(
+    name = "release",
+    srcs = [":release_files"],
+    outs = [
+        "bazel.tar.gz",
+        "bazel.tar.gz.sha256",
+    ],
+    cmd = """\
 set -euo pipefail
 
-COPYFILE_DISABLE=1 tar czvfh $(OUTS) --exclude ^bazel-out/ --exclude ^external/ *
+outs=($(OUTS))
+
+COPYFILE_DISABLE=1 tar czvfh "$${outs[0]}" \
+  --exclude ^bazel-out/ \
+  --exclude ^external/ \
+  *
+shasum -a 256 "$${outs[0]}" > "$${outs[1]}"
     """,
 )
 

--- a/BUILD
+++ b/BUILD
@@ -9,6 +9,8 @@ load(
     "xcodeproj",
 )
 
+# Targets
+
 swift_library(
     name = "SwiftLintFramework",
     srcs = glob(
@@ -40,17 +42,37 @@ swift_binary(
     ],
 )
 
+# Linting
+
 filegroup(
-    name = "SwiftLintConfig",
-    srcs = [".swiftlint.yml"],
+    name = "LintInputs",
+    srcs = glob(["Source/**/*.swift"]) + [
+        ".swiftlint.yml",
+        "//Tests:SwiftLintFrameworkTestsData",
+    ],
     visibility = ["//Tests:__subpackages__"],
 )
 
-filegroup(
-    name = "SourceFilesToLint",
-    srcs = glob(["Source/**"]),
-    visibility = ["//Tests:__subpackages__"],
+# Release
+
+genrule(
+    name = "release",
+    srcs = [
+        "//:BUILD",
+        "//:LICENSE",
+        "//:LintInputs",
+        "//Tests:BUILD",
+        "//bazel:BazelDirectorySources",
+    ],
+    outs = ["bazel.tar.gz"],
+    cmd = """
+set -euo pipefail
+
+COPYFILE_DISABLE=1 tar czvfh $(OUTS) --exclude ^bazel-out/ --exclude ^external/ *
+    """,
 )
+
+# Xcode Integration
 
 xcodeproj(
     name = "xcodeproj",

--- a/BUILD
+++ b/BUILD
@@ -109,3 +109,27 @@ xcodeproj(
         "//Tests:ExtraRulesTests",
     ],
 )
+
+filegroup(
+    name = "SourceAndTestFiles",
+    srcs = glob(["Source/**", "Tests/SwiftLintFrameworkTests/**"]),
+)
+
+genrule(
+    name = "write_swiftpm_yaml",
+    srcs = [":SourceAndTestFiles", "Package.swift", "Package.resolved"],
+    outs = ["swiftpm.yaml"],
+    cmd = """
+set -euo pipefail
+
+swift package clean
+swift build
+cp .build/debug.yaml $(OUTS)
+    """,
+)
+
+sh_test(
+    name = "analyze",
+    srcs = ["script/test-analyze.sh"],
+    data = [":swiftlint", ":LintInputs", "swiftpm.yaml"],
+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,9 @@ macOS < 12.
   [KokiHirokawa](https://github.com/KokiHirokawa)
   [#3986](https://github.com/realm/SwiftLint/issues/3986)
 
+* Add configuration to customise no space operators.  
+  [imben123](https://github.com/imben123)
+
 #### Bug Fixes
 
 * Ignore array types in `syntactic_sugar` rule if their associated `Index` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ accordingly._
 * The `--compile-commands` argument can now parse SwiftPM yaml files produced
   when running `swift build` at `.build/{debug,release}.yaml`.  
   [JP Simard](https://github.com/jpsim)
+* Add configuration to customise no space operators.  
+  [imben123](https://github.com/imben123)
 
 #### Bug Fixes
 
@@ -163,9 +165,6 @@ macOS < 12.
 * Support `UIEdgeInsets` type in `prefer_zero_over_explicit_init` rule.  
   [KokiHirokawa](https://github.com/KokiHirokawa)
   [#3986](https://github.com/realm/SwiftLint/issues/3986)
-
-* Add configuration to customise no space operators.  
-  [imben123](https://github.com/imben123)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,8 @@ accordingly._
 * The `--compile-commands` argument can now parse SwiftPM yaml files produced
   when running `swift build` at `.build/{debug,release}.yaml`.  
   [JP Simard](https://github.com/jpsim)
-* Add configuration to customise no space operators.  
+
+* Add new configuration option `allowed_no_space_operators` to `operator_usage_whitespace` rule. It allows to specify custom operators which shall not be considered by the rule.  
   [imben123](https://github.com/imben123)
 
 #### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ accordingly._
   [chrisjf](https://github.com/chrisjf)
   [#4060](https://github.com/realm/SwiftLint/issues/4060)
 
+* The `--compile-commands` argument can now parse SwiftPM yaml files produced
+  when running `swift build` at `.build/{debug,release}.yaml`.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Fix false positive in `self_in_property_initialization` rule when using

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,12 @@ package: build
 		--version "$(VERSION_STRING)" \
 		"$(OUTPUT_PACKAGE)"
 
-release: package portable_zip spm_artifactbundle_macos zip_linux_release
+bazel_release:
+	bazel build :release
+	mv bazel-bin/bazel.tar.gz .
+	shasum -a 256 bazel.tar.gz > bazel.tar.gz.sha256
+
+release: bazel_release package portable_zip spm_artifactbundle_macos zip_linux_release
 
 docker_image:
 	docker build --platform linux/amd64 --force-rm --tag swiftlint .

--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,7 @@ package: build
 
 bazel_release:
 	bazel build :release
-	mv bazel-bin/bazel.tar.gz .
-	shasum -a 256 bazel.tar.gz > bazel.tar.gz.sha256
+	mv bazel-bin/bazel.tar.gz bazel-bin/bazel.tar.gz.sha256 .
 
 release: bazel_release package portable_zip spm_artifactbundle_macos zip_linux_release
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -17,9 +17,9 @@ For SwiftLint contributors, follow these steps to cut a release:
     * Specify the tag you just pushed from the dropdown.
     * Set the release title to the new version number & release name.
     * Add the changelog section to the release description text box.
-    * Upload the pkg installer, framework zip, portable zip,
-      macos artifactbundle zip, and Linux zip you just built
-      to the GitHub release binaries.
+    * Upload the bazel tarball & SHA-256 signature, pkg installer,
+      framework zip, portable zip, macos artifactbundle zip, and Linux zip
+      you just built to the GitHub release binaries.
     * Click "Publish release".
 1. Publish to Homebrew and CocoaPods trunk: `make publish`
 1. Celebrate. :tada:

--- a/Source/SwiftLintFramework/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintFramework/Models/SwiftLintFile.swift
@@ -5,6 +5,7 @@ import SourceKittenFramework
 public final class SwiftLintFile {
     let file: File
     let id: UUID
+    private(set) var isTestFile = false
 
     /// Creates a `SwiftLintFile` with a SourceKitten `File`.
     ///
@@ -56,6 +57,11 @@ public final class SwiftLintFile {
     /// The parsed lines for this file's contents.
     public var lines: [Line] {
         return file.lines
+    }
+
+    /// Mark this file as used for testing purposes.
+    func markAsTestFile() {
+        isTestFile = true
     }
 
     /// Returns whether or not the file contains any attributes that require the Foundation module.

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -2,11 +2,13 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var linesLookAround = 2
     private(set) var skipAlignedConstants = true
+    private(set) var additionalAllowedNoSpaceOperators: [String] = []
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription
             + ", lines_look_around: \(linesLookAround)"
             + ", skip_aligned_constants: \(skipAlignedConstants)"
+            + ", additional_allowed_no_space_operators: \(additionalAllowedNoSpaceOperators)"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -16,6 +18,8 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
 
         linesLookAround = configuration["lines_look_around"] as? Int ?? 2
         skipAlignedConstants = configuration["skip_aligned_constants"] as? Bool ?? true
+        additionalAllowedNoSpaceOperators =
+            configuration["additional_allowed_no_space_operators"] as? [String] ?? []
 
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -2,13 +2,13 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var linesLookAround = 2
     private(set) var skipAlignedConstants = true
-    private(set) var additionalAllowedNoSpaceOperators: [String] = []
+    private(set) var allowedNoSpaceOperators: [String] = ["...", "..<"]
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription
             + ", lines_look_around: \(linesLookAround)"
             + ", skip_aligned_constants: \(skipAlignedConstants)"
-            + ", additional_allowed_no_space_operators: \(additionalAllowedNoSpaceOperators)"
+            + ", allowed_no_space_operators: \(allowedNoSpaceOperators)"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -18,8 +18,8 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
 
         linesLookAround = configuration["lines_look_around"] as? Int ?? 2
         skipAlignedConstants = configuration["skip_aligned_constants"] as? Bool ?? true
-        additionalAllowedNoSpaceOperators =
-            configuration["additional_allowed_no_space_operators"] as? [String] ?? []
+        allowedNoSpaceOperators =
+            configuration["allowed_no_space_operators"] as? [String] ?? ["...", "..<"]
 
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -27,7 +27,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 
     private func violationRanges(file: SwiftLintFile) -> [(ByteRange, String)] {
         OperatorUsageWhitespaceVisitor(
-            additionalAllowedNoSpaceOperators: configuration.additionalAllowedNoSpaceOperators
+            allowedNoSpaceOperators: configuration.allowedNoSpaceOperators
         )
         .walk(file: file, handler: \.violationRanges)
         .filter { byteRange, _ in
@@ -121,11 +121,11 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 }
 
 private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
-    private let additionalAllowedNoSpaceOperators: Set<String>
+    private let allowedNoSpaceOperators: Set<String>
     private(set) var violationRanges: [(ByteRange, String)] = []
 
-    init(additionalAllowedNoSpaceOperators: [String]) {
-        self.additionalAllowedNoSpaceOperators = Set(additionalAllowedNoSpaceOperators)
+    init(allowedNoSpaceOperators: [String]) {
+        self.allowedNoSpaceOperators = Set(allowedNoSpaceOperators)
     }
 
     override func visitPost(_ node: BinaryOperatorExprSyntax) {
@@ -172,10 +172,8 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
         let noSpacingAfter = operatorToken.trailingTrivia.isEmpty && nextToken.leadingTrivia.isEmpty
         let noSpacing = noSpacingBefore || noSpacingAfter
 
-        let allowedNoSpacingOperators = additionalAllowedNoSpaceOperators.union(["...", "..<"])
-
         let operatorText = operatorToken.withoutTrivia().text
-        if noSpacing && allowedNoSpacingOperators.contains(operatorText) {
+        if noSpacing && allowedNoSpaceOperators.contains(operatorText) {
             return nil
         }
 
@@ -197,7 +195,7 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
             length: endPosition - location
         )
 
-        let correction = allowedNoSpacingOperators.contains(operatorText) ? operatorText : " \(operatorText) "
+        let correction = allowedNoSpaceOperators.contains(operatorText) ? operatorText : " \(operatorText) "
         return (range, correction)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -84,9 +84,13 @@ internal enum OperatorUsageWhitespaceRuleExamples {
         """, excludeFromDocumentation: true),
         Example("""
         func getAllowedTimeRange(startTime: TimeOfDay) -> TimeOfDayRange {
-            return (startTime)<..<(startTime + 3.hours)
+            let endTime = startTime + 3.hours
+            return startTime<--<endTime
         }
-        """, configuration: ["additional_allowed_no_space_operators": ["⁝"]])
+        """,
+        configuration: ["allowed_no_space_operators": ["<--<"]],
+        excludeFromDocumentation: true
+        )
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -81,7 +81,12 @@ internal enum OperatorUsageWhitespaceRuleExamples {
         func success(for item: Item) {
             item.successHandler??()
         }
-        """, excludeFromDocumentation: true)
+        """, excludeFromDocumentation: true),
+        Example("""
+        func getAllowedTimeRange(startTime: TimeOfDay) -> TimeOfDayRange {
+            return (startTime)<..<(startTime + 3.hours)
+        }
+        """, configuration: ["additional_allowed_no_space_operators": ["⁝"]])
     ]
 
     static let triggeringExamples = [

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -37,6 +37,11 @@ struct LintOrAnalyzeCommand {
         try await Signposts.record(name: "LintOrAnalyzeCommand.run") {
             try await options.autocorrect ? autocorrect(options) : lintOrAnalyze(options)
         }
+
+#if os(Linux)
+        // Workaround for https://github.com/realm/SwiftLint/issues/4117
+        exit(0)
+#endif
     }
 
     private static func lintOrAnalyze(_ options: LintOrAnalyzeOptions) async throws {

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -204,11 +204,16 @@ struct LintableFilesVisitor {
     }
 
     private static func loadCompileCommands(_ path: String) throws -> [File: Arguments] {
-        guard let jsonContents = FileManager.default.contents(atPath: path) else {
+        guard let fileContents = FileManager.default.contents(atPath: path) else {
             throw CompileCommandsLoadError.nonExistentFile(path)
         }
 
-        guard let object = try? JSONSerialization.jsonObject(with: jsonContents),
+        if path.hasSuffix(".yaml") || path.hasSuffix(".yml") {
+            // Assume this is a SwiftPM yaml file
+            return try SwiftPMCompilationDB.parse(yaml: fileContents)
+        }
+
+        guard let object = try? JSONSerialization.jsonObject(with: fileContents),
             let compileDB = object as? [[String: Any]] else {
             throw CompileCommandsLoadError.malformedCommands(path)
         }

--- a/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
+++ b/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Yams
+
+private struct SwiftPMCommand: Codable {
+    let tool: String
+    let module: String?
+    let sources: [String]?
+    let args: [String]?
+    let importPaths: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case tool
+        case module = "module-name"
+        case sources
+        case args = "other-args"
+        case importPaths = "import-paths"
+    }
+}
+
+private struct SwiftPMNode: Codable {}
+
+private struct SwiftPMNodes: Codable {
+    let nodes: [String: SwiftPMNode]
+}
+
+struct SwiftPMCompilationDB: Codable {
+    private let commands: [String: SwiftPMCommand]
+
+    static func parse(yaml: Data) throws -> [File: Arguments] {
+        let decoder = YAMLDecoder()
+        let compilationDB: SwiftPMCompilationDB
+
+        if ProcessInfo.processInfo.environment["TEST_SRCDIR"] != nil {
+            // Running tests
+            let nodes = try decoder.decode(SwiftPMNodes.self, from: yaml)
+            let suffix = "/Source/swiftlint/"
+            let pathToReplace = Array(nodes.nodes.keys.filter({ node in
+                node.hasSuffix(suffix)
+            }))[0].dropLast(suffix.count - 1)
+            let stringFileContents = String(data: yaml, encoding: .utf8)!
+                .replacingOccurrences(of: pathToReplace, with: "")
+            compilationDB = try decoder.decode(Self.self, from: stringFileContents)
+        } else {
+            compilationDB = try decoder.decode(Self.self, from: yaml)
+        }
+
+        let swiftCompilerCommands = compilationDB.commands
+            .filter { $0.value.tool == "swift-compiler" }
+        let allSwiftSources = swiftCompilerCommands
+            .flatMap { $0.value.sources ?? [] }
+            .filter { $0.hasSuffix(".swift") }
+        return Dictionary(uniqueKeysWithValues: allSwiftSources.map { swiftSource in
+            let command = swiftCompilerCommands
+                .values
+                .first { $0.sources?.contains(swiftSource) == true }
+
+            guard let command = command,
+                  let module = command.module,
+                  let sources = command.sources,
+                  let arguments = command.args,
+                  let importPaths = command.importPaths
+            else {
+                return (swiftSource, [])
+            }
+
+            let args = ["-module-name", module] +
+                sources +
+                arguments.filteringCompilerArguments +
+                ["-I"] + importPaths
+
+            return (swiftSource, args)
+        })
+    }
+}

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -1,8 +1,9 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
 
-swift_library(
-    name = "SwiftLintFrameworkTests.library",
-    testonly = True,
+exports_files(["BUILD"])
+
+filegroup(
+    name = "SwiftLintFrameworkTestsSources",
     srcs = glob(
         ["SwiftLintFrameworkTests/**/*.swift"],
         exclude = [
@@ -11,6 +12,22 @@ swift_library(
             "SwiftLintFrameworkTests/FileNameNoSpaceRuleTests.swift",
         ],
     ),
+)
+
+filegroup(
+    name = "SwiftLintFrameworkTestsData",
+    srcs = glob(
+        ["SwiftLintFrameworkTests/**"],
+        # Bazel doesn't support paths with spaces in them
+        exclude = ["SwiftLintFrameworkTests/Resources/FileNameNoSpaceRuleFixtures/**"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "SwiftLintFrameworkTests.library",
+    testonly = True,
+    srcs = [":SwiftLintFrameworkTestsSources"],
     module_name = "SwiftLintFrameworkTests",
     deps = [
         "//:SwiftLintFramework",
@@ -19,14 +36,7 @@ swift_library(
 
 swift_test(
     name = "SwiftLintFrameworkTests",
-    data = [
-        "//:SwiftLintConfig",
-        "//:SourceFilesToLint",
-    ] + glob(
-        ["SwiftLintFrameworkTests/**"],
-        # Bazel doesn't support paths with spaces in them
-        exclude = ["SwiftLintFrameworkTests/Resources/FileNameNoSpaceRuleFixtures/**"],
-    ),
+    data = ["//:LintInputs"],
     visibility = ["//visibility:public"],
     deps = [":SwiftLintFrameworkTests.library"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,13 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_apple/releases/download/1.0.1/rules_apple.1.0.1.tar.gz",
 )
 
+http_archive(
+    name = "build_bazel_rules_swift",
+    sha256 = "7a25fa865205f96fe4924ed137fed02a1b9529afd82ffd14e52186a0aa222cad",
+    strip_prefix = "rules_swift-469db13330e94af864540d50acdfc742998ef292",
+    url = "https://github.com/bazelbuild/rules_swift/archive/469db13330e94af864540d50acdfc742998ef292.tar.gz",
+)
+
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,15 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "36072d4f3614d309d6a703da0dfe48684ec4c65a89611aeb9590b45af7a3e592",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/1.0.1/rules_apple.1.0.1.tar.gz",
-)
-
-http_archive(
-    name = "build_bazel_rules_swift",
-    sha256 = "7a25fa865205f96fe4924ed137fed02a1b9529afd82ffd14e52186a0aa222cad",
-    strip_prefix = "rules_swift-469db13330e94af864540d50acdfc742998ef292",
-    url = "https://github.com/bazelbuild/rules_swift/archive/469db13330e94af864540d50acdfc742998ef292.tar.gz",
+    sha256 = "f003875c248544009c8e8ae03906bbdacb970bc3e5931b40cd76cadeded99632",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/1.1.0/rules_apple.1.1.0.tar.gz",
 )
 
 load(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,8 +88,6 @@ jobs:
       displayName: Pre-cache SwiftLint Run
     - script: swift run --configuration release --sanitize thread swiftlint lint --lenient
       displayName: Post-cache SwiftLint Run
-    - script: make test_tsan
-      displayName: Test With TSan
 
 - job: jazzy
   pool:

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -5,31 +5,31 @@ filegroup(
 )
 
 xcode_version(
-    name = "version14_0_0_14A5294e",
+    name = "version14_0_0_14A5294g",
     aliases = [
-        "14.0.0.14A5294e",
-        "14A5294e",
+        "14.0.0.14A5294g",
+        "14A5294g",
     ],
     default_ios_sdk_version = "16.0",
     default_macos_sdk_version = "13.0",
     default_tvos_sdk_version = "16.0",
     default_watchos_sdk_version = "9.0",
-    version = "14.0.0.14A5294e",
+    version = "14.0.0.14A5294g",
 )
 
 available_xcodes(
     name = "local_xcodes",
-    default = ":version14_0_0_14A5294e",
+    default = ":version14_0_0_14A5294g",
     versions = [
-        ":version14_0_0_14A5294e",
+        ":version14_0_0_14A5294g",
     ],
 )
 
 available_xcodes(
     name = "remote_xcodes",
-    default = ":version14_0_0_14A5294e",
+    default = ":version14_0_0_14A5294g",
     versions = [
-        ":version14_0_0_14A5294e",
+        ":version14_0_0_14A5294g",
     ],
 )
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -3,3 +3,38 @@ filegroup(
     srcs = glob(["*"]),
     visibility = ["//visibility:public"],
 )
+
+xcode_version(
+    name = "version14_0_0_14A5294e",
+    aliases = [
+        "14.0.0.14A5294e",
+        "14A5294e",
+    ],
+    default_ios_sdk_version = "16.0",
+    default_macos_sdk_version = "13.0",
+    default_tvos_sdk_version = "16.0",
+    default_watchos_sdk_version = "9.0",
+    version = "14.0.0.14A5294e",
+)
+
+available_xcodes(
+    name = "local_xcodes",
+    default = ":version14_0_0_14A5294e",
+    versions = [
+        ":version14_0_0_14A5294e",
+    ],
+)
+
+available_xcodes(
+    name = "remote_xcodes",
+    default = ":version14_0_0_14A5294e",
+    versions = [
+        ":version14_0_0_14A5294e",
+    ],
+)
+
+xcode_config(
+    name = "xcode_config",
+    local_versions = ":local_xcodes",
+    remote_versions = ":remote_xcodes",
+)

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,6 @@
+filegroup(
+    name = "BazelDirectorySources",
+    srcs = glob(["*"]),
+    visibility = ["//visibility:public"],
+)
+

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,6 +1,5 @@
 filegroup(
-    name = "BazelDirectorySources",
+    name = "release_files",
     srcs = glob(["*"]),
     visibility = ["//visibility:public"],
 )
-

--- a/script/test-analyze.sh
+++ b/script/test-analyze.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly swiftlint="$RUNFILES_DIR/SwiftLint/swiftlint"
+readonly swiftpm_yaml="$RUNFILES_DIR/SwiftLint/swiftpm.yaml"
+cd "$PROJECT_ROOT"
+"$swiftlint" analyze --strict --compile-commands "$swiftpm_yaml"


### PR DESCRIPTION
In some projects it is possible developers may have custom operators which make sense without surrounding spaces.

Currently the rule has two operators hard-coded which are exempt from having spaces either side; `...` and `..<`. This PR allows users to customise this behaviour by providing additional operators which they also want excluded from this condition.

This will allow them to create their own range-style custom operators. For example, a user may include this in their `.swiftlint.yml`:
```yaml
operator_usage_whitespace:
  additional_allowed_no_space_operators: [ "<..<" ]
```

----
Another example is that we use a custom "tricolon" operator as an abbreviation for creating our custom `TimeOfDay` class.
```swift
let midday: TimeOfDay = 12⁝00
```
This operator similarly doesn't make sense with spaces either side of it.